### PR TITLE
Add previous/next buttons to update pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,15 +1,29 @@
 ---
 layout: default
 ---
-<div class="post">
 
+<div class="post">
   <header class="post-header">
     <h1 class="post-title">{{ page.title }}</h1>
-    <p class="post-meta">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+    <p class="post-meta">
+      {{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author
+      }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}
+    </p>
   </header>
 
-  <article class="post-content">
-    {{ content }}
-  </article>
+  <article class="post-content">{{ content }}</article>
 
+  <div class="paging-div">
+    {% if page.previous %}<a
+      class="wooden-button paging-button"
+      href="{{page.previous.url}}"
+    >
+      Previous </a
+    >{% endif %} {% if page.next %}<a
+      class="wooden-button paging-button"
+      href="{{page.next.url}}"
+    >
+      Next </a
+    >{% endif %}
+  </div>
 </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -205,6 +205,19 @@
 
 }
 
+.paging-div {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+}
+
+.paging-button {
+    min-width: 120px;
+    max-width: 180px;
+    font-size: 18px;
+    display: inline-block;
+}
+
 /**
  * Site footer
  */


### PR DESCRIPTION
When I was reading through the blog posts, it was a bit of a pain to go index -> page -> index -> next page. I went through and added simple previous/next buttons in the style of the existing play button, which makes it a lot more pleasant to navigate the blog.

## Samples
1-Button Mobile
<img width="399" alt="image" src="https://github.com/michal-bures/konkr_web/assets/26288229/f8e1bc1f-2b05-48f0-93ba-51664c7ddffc">
2-Button Mobile
<img width="396" alt="image" src="https://github.com/michal-bures/konkr_web/assets/26288229/499b937b-4bd1-48b6-bda6-20e667434786">
1-Button desktop
<img width="1008" alt="image" src="https://github.com/michal-bures/konkr_web/assets/26288229/58688f26-84a9-4db7-8014-83b5f3cf8ac4">
2-Button desktop
<img width="998" alt="image" src="https://github.com/michal-bures/konkr_web/assets/26288229/93f25fb1-fccc-4af6-89e1-92485e09283a">
